### PR TITLE
feat: implemented calander toggle for daily/weekly/monthly views

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,9 +1,74 @@
-import { Box } from "@chakra-ui/react";
+"use client";
+import { Box, VStack, Text, HStack } from "@chakra-ui/react";
 import MonthlyCalendar from "@/components/MonthlyCalendar";
+import React from "react";
+import CalendarSubHeader from "@/components/CalendarSubHeader";
 export default function Page() {
+  const [view, setView] = React.useState<"D" | "W" | "M">("M");
+
+  const styleButton = (selectView: string, option: string) => {
+    const selected = selectView === option;
+    return {
+      w: "30px",
+      h: "30px",
+      borderRadius: "full",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      cursor: "pointer",
+      bg: selected ? "blue.400" : "transparent",
+      color: "black",
+      _hover: {
+        bg: selected ? "#5C7DE0" : "#DDE0EC",
+      },
+    };
+  };
+
+  const showCalendar = (selectCalendar: string) => {
+    if (selectCalendar === "D")
+      return (
+        <>
+          <CalendarSubHeader date="January 5th"></CalendarSubHeader>
+          <Box></Box>
+        </>
+      );
+    else if (selectCalendar === "W")
+      return (
+        <>
+          <CalendarSubHeader date="January 4-10"></CalendarSubHeader>
+          <Box></Box>
+        </>
+      );
+    else
+      return (
+        <>
+          <CalendarSubHeader date="January 2026"></CalendarSubHeader>
+          <MonthlyCalendar></MonthlyCalendar>
+        </>
+      );
+  };
+
   return (
     <Box display={"flex"} justifyContent={"center"}>
-      <MonthlyCalendar></MonthlyCalendar>
+      <VStack maxW="345px" align="stretch" w="full" gap={2} px={3} py={3}>
+        <HStack justify="space-between" align="center">
+          <Text fontSize="34px" fontWeight="semibold" color="black">
+            My Calendar
+          </Text>
+          <HStack bg="#E6E8F2" px={1} py={1} borderRadius="full" align="center">
+            <Box {...styleButton(view, "D")} onClick={() => setView("D")}>
+              D
+            </Box>
+            <Box {...styleButton(view, "W")} onClick={() => setView("W")}>
+              W
+            </Box>
+            <Box {...styleButton(view, "M")} onClick={() => setView("M")}>
+              M
+            </Box>
+          </HStack>
+        </HStack>
+        {showCalendar(view)}
+      </VStack>
     </Box>
   );
 }

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -3,26 +3,10 @@ import { Box, VStack, Text, HStack } from "@chakra-ui/react";
 import MonthlyCalendar from "@/components/MonthlyCalendar";
 import React from "react";
 import CalendarSubHeader from "@/components/CalendarSubHeader";
+import CalendarSwitchButton from "@/components/CalendarSwitchButton";
+
 export default function Page() {
   const [view, setView] = React.useState<"D" | "W" | "M">("M");
-
-  const styleButton = (selectView: string, option: string) => {
-    const selected = selectView === option;
-    return {
-      w: "30px",
-      h: "30px",
-      borderRadius: "full",
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      cursor: "pointer",
-      bg: selected ? "blue.400" : "transparent",
-      color: "black",
-      _hover: {
-        bg: selected ? "#5C7DE0" : "#DDE0EC",
-      },
-    };
-  };
 
   const showCalendar = (selectCalendar: string) => {
     if (selectCalendar === "D")
@@ -56,15 +40,9 @@ export default function Page() {
             My Calendar
           </Text>
           <HStack bg="#E6E8F2" px={1} py={1} borderRadius="full" align="center">
-            <Box {...styleButton(view, "D")} onClick={() => setView("D")}>
-              D
-            </Box>
-            <Box {...styleButton(view, "W")} onClick={() => setView("W")}>
-              W
-            </Box>
-            <Box {...styleButton(view, "M")} onClick={() => setView("M")}>
-              M
-            </Box>
+            <CalendarSwitchButton label="D" selected={view === "D"} onClick={() => setView("D")} />
+            <CalendarSwitchButton label="W" selected={view === "W"} onClick={() => setView("W")} />
+            <CalendarSwitchButton label="M" selected={view === "M"} onClick={() => setView("M")} />
           </HStack>
         </HStack>
         {showCalendar(view)}

--- a/src/components/CalendarSubHeader.tsx
+++ b/src/components/CalendarSubHeader.tsx
@@ -1,0 +1,25 @@
+import { Box, VStack, Text, HStack, IconButton } from "@chakra-ui/react";
+import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
+
+type CalendarSubHeaderProps = {
+  date: string;
+};
+
+export default function CalendarSubHeader({ date }: CalendarSubHeaderProps) {
+  return (
+    <HStack w={"full"} h={"29px"} justify="space-between" align="center">
+      <Text fontSize="24px" fontWeight="semibold" color="black">
+        {date}
+      </Text>
+      <HStack gap={2}>
+        <IconButton variant="ghost" size={"xs"}>
+          <FaChevronLeft />
+        </IconButton>
+
+        <IconButton variant="ghost" size={"xs"}>
+          <FaChevronRight />
+        </IconButton>
+      </HStack>
+    </HStack>
+  );
+}

--- a/src/components/CalendarSwitchButton.tsx
+++ b/src/components/CalendarSwitchButton.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Box, BoxProps } from "@chakra-ui/react";
+
+type CalendarSwitchProps = BoxProps & {
+  selected: boolean;
+  onClick: () => void;
+  label: string;
+};
+
+export default function CalendarSwitchButton({ selected, onClick, label, ...rest }: CalendarSwitchProps) {
+  return (
+    <Box
+      w="30px"
+      h="30px"
+      borderRadius="full"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      cursor="pointer"
+      bg={selected ? "blue.400" : "transparent"}
+      color="black"
+      _hover={{
+        bg: selected ? "#5C7DE0" : "DDE0EC",
+      }}
+      onClick={onClick}
+      {...rest}
+    >
+      {label}
+    </Box>
+  );
+}

--- a/src/components/MonthlyCalendar.tsx
+++ b/src/components/MonthlyCalendar.tsx
@@ -46,21 +46,6 @@ export default function MonthlyCalendar() {
   ];
   return (
     <VStack maxW="345px" w="full" align="stretch" gap={0}>
-      {/* Top row with month on left and arrows on the right */}
-      <HStack w={"full"} h={"29px"} justify="space-between" align="center">
-        <Text fontSize="24px" fontWeight="semibold" color="black">
-          January
-        </Text>
-        <HStack gap={2}>
-          <IconButton variant="ghost" size={"xs"}>
-            <FaChevronLeft />
-          </IconButton>
-
-          <IconButton variant="ghost" size={"xs"}>
-            <FaChevronRight />
-          </IconButton>
-        </HStack>
-      </HStack>
       {/* Wrapper for weekday row and day grid */}
       <Box>
         {/* Weekday labels */}


### PR DESCRIPTION
## Developer: Seamus Connolly

Closes #35 

### Pull Request Summary
I added a toggle button for the calendar to switch between daily, weekly, and monthly views. 
{Describe the purpose of your pull request}

### Modifications
{list out the files created/modified and a brief description of what was changed}
-Modified calendar's page.tsx to add toggle button 
-Modified MonthlyCalendar component by pulling out the sub header with month and arrows
-Made a new component called CalendarSubHeader which takes the sub header extracted from MonthlyCalendar and makes it applicable to each of the modes. 



### Testing Considerations
{list out what you have tested and what the reviewer should verify}
Tested if it worked and operated multiple different times. Reviewer should verify if it fit the spec and code correctness, since this is my first issue completed.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}

https://github.com/user-attachments/assets/3e5817e3-9c09-4ad1-978e-badea7c603fe

