### PR TITLE
Implement home card with streak and progress ring

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import { IUsers } from "@/database/userSchema";
 import { useRouter } from "next/navigation";
+import StreakCard from "@/components/StreakCard";
 
 export default function Home() {
   const { isSignedIn, user, isLoaded } = useUser();
@@ -64,7 +65,7 @@ export default function Home() {
             </Link>
           </HStack>
           {/* Progress Ring */}
-          <VStack w={"full"} gap={5} padding={"20px"}>
+          <VStack w={"full"} gap={5} py={"20px"}>
             <HStack w={"full"} justifyContent={"space-between"}>
               <IconButton area-label="Previous Progress Ring" variant={"ghost"}>
                 <LuChevronLeft />
@@ -76,7 +77,7 @@ export default function Home() {
                 <LuChevronRight />
               </IconButton>
             </HStack>
-            <ProgressRing percent={70} isClockwise={false} />
+            <StreakCard></StreakCard>
           </VStack>
           {/* Tasks */}
           <TaskList userId={userData ? String(userData._id) : undefined} />

--- a/src/components/MultiDayStreak.tsx
+++ b/src/components/MultiDayStreak.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { HStack, VStack, Text, Icon, Box } from "@chakra-ui/react";
+import { FaFire } from "react-icons/fa";
+
+type DayItem = { label: string; offset: number; isToday: boolean };
+
+const DAY_LABELS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"] as const;
+
+function getCenteredDayItems(): DayItem[] {
+  const todayIndex = new Date().getDay(); // 0..6
+  const offsets = [-2, -1, 0, 1, 2];
+  return offsets.map((offset) => {
+    const idx = (todayIndex + offset + 7) % 7;
+    return { label: DAY_LABELS[idx], offset, isToday: offset === 0 };
+  });
+}
+
+export default function MultiDayStreak({ streakDays }: { streakDays: number }) {
+  const days = getCenteredDayItems();
+
+  return (
+    <VStack align="start" flex="1" gap={0}>
+      {/* Title + subtitle grouped tightly */}
+      <VStack align="start" gap={0}>
+        <Text fontSize="22px" fontWeight="bold" color="gray.800">
+          {streakDays} day streak
+        </Text>
+
+        <Text fontSize="lg" color="gray.600">
+          You&apos;re on a roll!
+        </Text>
+      </VStack>
+
+      {/* Day row */}
+      <HStack pt={3} gap={4}>
+        {days.map((day) => {
+          // active if day is today or previous and within streak length
+          const active = day.offset <= 0 && Math.abs(day.offset) < Math.max(1, streakDays);
+
+          return (
+            <VStack key={`${day.label}-${day.offset}`} gap={2} align="center">
+              <Text fontSize="sm" color="gray.600">
+                {day.label}
+              </Text>
+
+              {active ? (
+                // active flames (today and previous days covered by the streak)
+                <Icon as={FaFire} boxSize={5} color="cyan.600" />
+              ) : (
+                // inactive placeholder dots/circles
+                <Box w="18px" h="18px" borderRadius="full" bg="gray.200" />
+              )}
+            </VStack>
+          );
+        })}
+      </HStack>
+    </VStack>
+  );
+}

--- a/src/components/ProgressRing.tsx
+++ b/src/components/ProgressRing.tsx
@@ -1,4 +1,5 @@
-import { Box, Text, ProgressCircle, AbsoluteCenter } from "@chakra-ui/react";
+import { Box, Text, ProgressCircle, AbsoluteCenter, Icon } from "@chakra-ui/react";
+import { FaFire } from "react-icons/fa";
 
 //// Custom progress ring component configurable with size, thickness, and direction of progress indicator
 export default function ProgressRing({ percent = 0, isClockwise = true, size = "270px", thickness = "30px" }) {
@@ -20,9 +21,7 @@ export default function ProgressRing({ percent = 0, isClockwise = true, size = "
         <ProgressCircle.Range strokeLinecap="round" />
       </ProgressCircle.Circle>
       <AbsoluteCenter>
-        <ProgressCircle.ValueText fontSize="6xl" fontWeight="bold">
-          {clampedPercent}%
-        </ProgressCircle.ValueText>
+        <Icon as={FaFire} boxSize={16} color="cyan.600" />
       </AbsoluteCenter>
     </ProgressCircle.Root>
   );

--- a/src/components/StreakCard.tsx
+++ b/src/components/StreakCard.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Box, HStack, VStack, Text } from "@chakra-ui/react";
+import ProgressRing from "@/components/ProgressRing";
+import MultiDayStreak from "@/components/MultiDayStreak";
+
+export default function StreakCard() {
+  return (
+    <Box w="full" bg="gray.50" borderRadius="2xl" p={5} boxShadow="sm" borderWidth="1px" borderColor="gray.100">
+      <HStack align="center" gap={6}>
+        <ProgressRing percent={70} isClockwise={false} size="140px" thickness="16px" />
+        <MultiDayStreak streakDays={5} />
+      </HStack>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Developer: Seamus Connolly

Closes #37 

### Pull Request Summary
Made box to contain progress ring and streak
Added streak with flame that shows current day, with past 2 and future 2 days
Highlights the past days as blue if the streak is long enough


### Modifications
Made StreakCard.tsx which contains the progress ring and streak
Made MultiDayStreak.tsx which is component of streak, so that StreakCard only has to call ProgressRing and MultiDayStreak
Modified ProgressRing.tsx to include flame
Modified page.tsx of home page to call StreakCard component

### Testing Considerations

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or
<img width="741" height="791" alt="Screenshot 2026-03-04 at 10 51 47 PM" src="https://github.com/user-attachments/assets/523178e9-e6cf-4891-88bb-4dca669fe076" />
<img width="359" height="806" alt="Screenshot 2026-03-04 at 10 52 43 PM" src="https://github.com/user-attachments/assets/f0716bf1-4fad-4f7f-9e59-f3404a87571d" />

 even better a screencast displaying the functionality}
