### PR TITLE
Add admin settings pages

### DIFF
--- a/src/app/admin/manage-challenges/page.tsx
+++ b/src/app/admin/manage-challenges/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { Box, Text, VStack, HStack, Input, IconButton } from "@chakra-ui/react";
+import { LuChevronLeft, LuSearch, LuPlus } from "react-icons/lu";
+
+export default function ManageChallengePage() {
+  return (
+    <Box display="flex" justifyContent="center" minH="100vh">
+      <Box maxW="400px" w="full" minH="100vh" p={5} pb={{ base: "140px", md: "40px" }}>
+        <VStack align="stretch" gap={4}>
+          <HStack gap={3}>
+            <Link href="/admin" style={{ display: "flex", alignItems: "center" }}>
+              <LuChevronLeft size={28} />
+            </Link>
+
+            <Text fontWeight="semibold" fontSize="4xl">
+              Challenges
+            </Text>
+          </HStack>
+
+          <Box position="relative">
+            <Input placeholder="Search for a challenge..." bg="gray.200" border="none" borderRadius="full" pr="45px" />
+
+            <Box
+              position="absolute"
+              right="14px"
+              top="50%"
+              transform="translateY(-50%)"
+              color="gray.500"
+              pointerEvents="none"
+            >
+              <LuSearch />
+            </Box>
+          </Box>
+        </VStack>
+      </Box>
+
+      <IconButton
+        aria-label="Add challenge"
+        position="fixed"
+        bottom={{ base: "110px", md: "24px" }}
+        right="24px"
+        w="64px"
+        h="64px"
+        borderRadius="full"
+        variant="outline"
+        borderColor="blue.300"
+        color="blue.300"
+        bg="white"
+        zIndex={20}
+      >
+        <LuPlus size={28} />
+      </IconButton>
+    </Box>
+  );
+}

--- a/src/app/admin/manage-tasks/page.tsx
+++ b/src/app/admin/manage-tasks/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { Box, Text, VStack, HStack, Input, IconButton } from "@chakra-ui/react";
+import { LuChevronLeft, LuSearch, LuPlus } from "react-icons/lu";
+
+export default function ManageTasksPage() {
+  return (
+    <Box display="flex" justifyContent="center" minH="100vh">
+      <Box maxW="400px" w="full" minH="100vh" p={5} pb={{ base: "140px", md: "40px" }}>
+        <VStack align="stretch" gap={4}>
+          <HStack gap={3}>
+            <Link href="/admin" style={{ display: "flex", alignItems: "center" }}>
+              <LuChevronLeft size={28} />
+            </Link>
+
+            <Text fontWeight="semibold" fontSize="4xl">
+              Task Manager
+            </Text>
+          </HStack>
+
+          <Box position="relative">
+            <Input placeholder="Search for a task..." bg="gray.200" border="none" borderRadius="full" pr="45px" />
+
+            <Box
+              position="absolute"
+              right="14px"
+              top="50%"
+              transform="translateY(-50%)"
+              color="gray.500"
+              pointerEvents="none"
+            >
+              <LuSearch />
+            </Box>
+          </Box>
+        </VStack>
+      </Box>
+
+      <IconButton
+        aria-label="Add task"
+        position="fixed"
+        bottom={{ base: "110px", md: "24px" }}
+        right="24px"
+        w="64px"
+        h="64px"
+        borderRadius="full"
+        variant="outline"
+        borderColor="blue.300"
+        color="blue.300"
+        bg="white"
+        zIndex={20}
+      >
+        <LuPlus size={28} />
+      </IconButton>
+    </Box>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { Box, Text, VStack, HStack } from "@chakra-ui/react";
+import { LuChevronLeft, LuChevronRight } from "react-icons/lu";
+
+export default function AdminPage() {
+  return (
+    <Box display="flex" justifyContent="center">
+      <VStack maxW="400px" align="stretch" w="full" gap={4} p={5}>
+        <HStack gap={3}>
+          <Link href="/profile" style={{ display: "flex", alignItems: "center" }}>
+            <LuChevronLeft size={28} />
+          </Link>
+          <Text fontWeight="semibold" fontSize="4xl">
+            Admin Settings
+          </Text>
+        </HStack>
+
+        <VStack bg="gray.200" p={2} rounded="md" align="stretch" gap={2}>
+          <Link href="/admin/manage-tasks" style={{ textDecoration: "none", color: "inherit" }}>
+            <HStack w="full" justifyContent="space-between" cursor="pointer" p={2}>
+              <Text fontWeight="normal" fontSize="md">
+                Edit available tasks
+              </Text>
+              <LuChevronRight />
+            </HStack>
+          </Link>
+
+          <Link href="/admin/manage-challenges" style={{ textDecoration: "none", color: "inherit" }}>
+            <HStack w="full" justifyContent="space-between" cursor="pointer" p={2}>
+              <Text fontWeight="normal" fontSize="md">
+                Edit available challenges
+              </Text>
+              <LuChevronRight />
+            </HStack>
+          </Link>
+        </VStack>
+      </VStack>
+    </Box>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Box, Text, VStack, HStack } from "@chakra-ui/react";
-import { LuSettings, LuSquarePen, LuChevronRight, LuHeart } from "react-icons/lu";
+import { LuSettings, LuSquarePen, LuChevronRight, LuHeart, LuShieldCheck } from "react-icons/lu";
 import { SignOutButton } from "@clerk/nextjs";
 import { useUser } from "@clerk/nextjs";
 import Link from "next/link";
@@ -19,6 +19,7 @@ export default function Page() {
             <LuSettings size={30} />
           </Link>
         </HStack>
+
         <Box bg="gray.200" p={2} w="full" justifyContent="space-between" rounded="md">
           <Text fontWeight="medium" fontSize="2xl" alignContent={"left"}>
             {user ? user.fullName : ""}
@@ -27,7 +28,8 @@ export default function Page() {
             {user ? String(user.emailAddresses[0]) : ""}
           </Text>
         </Box>
-        <VStack bg="gray.200" p={2} my={4} rounded="md">
+
+        <VStack bg="gray.200" p={2} my={4} rounded="md" align="stretch">
           <HStack w="full" justifyContent="space-between">
             <HStack>
               <LuSquarePen />
@@ -37,6 +39,7 @@ export default function Page() {
             </HStack>
             <LuChevronRight />
           </HStack>
+
           <HStack w="full" justifyContent="space-between">
             <HStack>
               <LuHeart />
@@ -46,7 +49,20 @@ export default function Page() {
             </HStack>
             <LuChevronRight />
           </HStack>
+
+          <Link href="/admin" style={{ textDecoration: "none", color: "inherit" }}>
+            <HStack w="full" justifyContent="space-between" cursor="pointer">
+              <HStack>
+                <LuShieldCheck />
+                <Text fontWeight="normal" fontSize="md">
+                  Admin Settings
+                </Text>
+              </HStack>
+              <LuChevronRight />
+            </HStack>
+          </Link>
         </VStack>
+
         <VStack bgColor="#296184" rounded="md" fontSize="md" color="white">
           <SignOutButton />
         </VStack>


### PR DESCRIPTION
## Developer: Jonathan Lau

Closes #65 

### Pull Request Summary

Here is what I did:
- added Admin Settings link to profile page
- added admin landing page
- added manage tasks page
- added manage challenges page
- added search bars and add buttons for task/challenge manager pages

- if needed I could remove the bottom navbar from them!
### Modifications

{list out the files created/modified and a brief description of what was changed}

### Testing Considerations

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
<img width="527" height="403" alt="image" src="https://github.com/user-attachments/assets/d7bc29c5-c145-45cb-8ee2-e28e4d60364b" />
<img width="410" height="664" alt="image" src="https://github.com/user-attachments/assets/9c30cb77-2077-47c6-bfa0-8f0a1f801d56" />
<img width="412" height="787" alt="image" src="https://github.com/user-attachments/assets/fe429602-d00a-4a10-9ab5-f86a5294da78" />
<img width="395" height="761" alt="image" src="https://github.com/user-attachments/assets/e3a9c66e-3b3e-4d37-923c-73bb21c82ba3" />

