### PR TITLE
Add swipeable resource list component

### DIFF
--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -109,12 +109,16 @@ export default function Page() {
   const resourcesToShow = activeTab === "discover" ? visibleResources : savedResources;
 
   return (
-    <Box minH="100vh" bg="#F9FAFB" px={6} pt={10} pb={28}>
-      <Box maxW="560px" mx="auto">
-        <HStack gap={4} mb={8}>
+    <Box display={"flex"} justifyContent={"center"}>
+      <VStack maxW="400px" align="stretch" w="full" gap={2} p={5}>
+        <Text fontSize="4xl" letterSpacing="-0.05em" whiteSpace="nowrap" fontWeight={"semibold"} pb={4}>
+          Resources
+        </Text>
+        <Box maxW="560px" mx="auto">
           <HStack
+            mb={5}
             flex={1}
-            h="74px"
+            h="56px"
             bg="white"
             borderRadius="full"
             px={6}
@@ -133,79 +137,65 @@ export default function Page() {
             <LuSearch size={32} color="black" />
           </HStack>
 
-          <Box
-            h="74px"
-            w="74px"
-            bg="white"
-            borderRadius="full"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            boxShadow="0px 1px 8px rgba(89, 91, 98, 0.08)"
-            border="1px solid #EEF0F2"
-          >
-            <LuBell size={30} color="black" />
-          </Box>
-        </HStack>
-
-        <HStack mb={6}>
-          <ResourcesTabButton
-            label="Discover"
-            active={activeTab === "discover"}
-            onClick={() => setActiveTab("discover")}
-          />
-          <ResourcesTabButton label="Saved" active={activeTab === "saved"} onClick={() => setActiveTab("saved")} />
-        </HStack>
-
-        {activeTab === "discover" && (
-          <Box
-            bg="#EAF4FB"
-            borderRadius="26px"
-            minH="234px"
-            px={8}
-            pb={8}
-            mb={8}
-            display="flex"
-            flexDirection="column"
-            justifyContent="flex-end"
-          >
-            <Text fontSize="3xl" fontWeight="bold" color="black" lineHeight="1.1">
-              Featured Resource
-            </Text>
-            <Text fontSize="md" color="black">
-              Resource Description
-            </Text>
-          </Box>
-        )}
-
-        <VStack align="stretch" gap={5}>
-          {resourcesToShow.map((resource) => (
-            <ResourceListCard
-              key={resource.id}
-              title={resource.title}
-              description={resource.description}
-              interestTags={resource.interestTags}
-              variant={activeTab}
-              onSave={() => handleSave(resource.id)}
-              onDelete={() => handleDelete(resource.id)}
+          <HStack mb={6}>
+            <ResourcesTabButton
+              label="Discover"
+              active={activeTab === "discover"}
+              onClick={() => setActiveTab("discover")}
             />
-          ))}
+            <ResourcesTabButton label="Saved" active={activeTab === "saved"} onClick={() => setActiveTab("saved")} />
+          </HStack>
 
-          {resourcesToShow.length === 0 && (
+          {activeTab === "discover" && (
             <Box
-              bg="white"
-              borderRadius="20px"
-              p={6}
-              textAlign="center"
-              boxShadow="0px 4px 18px rgba(89, 91, 98, 0.10)"
+              bg="#EAF4FB"
+              borderRadius="26px"
+              minH="234px"
+              px={8}
+              pb={8}
+              mb={8}
+              display="flex"
+              flexDirection="column"
+              justifyContent="flex-end"
             >
-              <Text fontWeight="semibold" color="black">
-                No resources found.
+              <Text fontSize="3xl" fontWeight="bold" color="black" lineHeight="1.1">
+                Featured Resource
+              </Text>
+              <Text fontSize="md" color="black">
+                Resource Description
               </Text>
             </Box>
           )}
-        </VStack>
-      </Box>
+
+          <VStack align="stretch" gap={5}>
+            {resourcesToShow.map((resource) => (
+              <ResourceListCard
+                key={resource.id}
+                title={resource.title}
+                description={resource.description}
+                interestTags={resource.interestTags}
+                variant={activeTab}
+                onSave={() => handleSave(resource.id)}
+                onDelete={() => handleDelete(resource.id)}
+              />
+            ))}
+
+            {resourcesToShow.length === 0 && (
+              <Box
+                bg="white"
+                borderRadius="20px"
+                p={6}
+                textAlign="center"
+                boxShadow="0px 4px 18px rgba(89, 91, 98, 0.10)"
+              >
+                <Text fontWeight="semibold" color="black">
+                  No resources found.
+                </Text>
+              </Box>
+            )}
+          </VStack>
+        </Box>
+      </VStack>
     </Box>
   );
 }

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,9 +1,211 @@
-export default function Page() {
+"use client";
+
+import { useMemo, useState } from "react";
+import { Box, HStack, Input, Text, VStack } from "@chakra-ui/react";
+import { LuBell, LuSearch } from "react-icons/lu";
+import ResourceListCard from "@/components/ResourceListCard";
+
+type ResourcesTab = "discover" | "saved";
+
+interface ExampleResource {
+  id: string;
+  title: string;
+  description: string;
+  interestTags: string[];
+}
+
+const EXAMPLE_RESOURCES: ExampleResource[] = [
+  {
+    id: "energy-saving",
+    title: "Resource Title",
+    interestTags: ["Energy Saving"],
+    description:
+      "Resource Description. Learn simple ways to reduce electricity use at home, lower your utility bill, and make everyday choices that help limit your carbon footprint.",
+  },
+  {
+    id: "shopping",
+    title: "Resource Title",
+    interestTags: ["Shopping"],
+    description:
+      "Resource Description. Find lower-waste shopping habits, reusable swaps, and sustainable purchasing tips for everyday items.",
+  },
+  {
+    id: "waste-reduction",
+    title: "Resource Title",
+    interestTags: ["Waste Reduction"],
+    description:
+      "Resource Description. Explore practical ways to reduce household waste, reuse materials, and recycle more effectively.",
+  },
+  {
+    id: "nature-preservation",
+    title: "Resource Title",
+    interestTags: ["Nature Preservation & Restoration"],
+    description:
+      "Resource Description. Discover local and everyday actions that support native plants, habitat restoration, and healthier outdoor spaces.",
+  },
+  {
+    id: "transportation",
+    title: "Resource Title",
+    interestTags: ["Transportation"],
+    description:
+      "Resource Description. Compare transportation choices that can reduce emissions, including walking, biking, public transit, and carpooling.",
+  },
+];
+
+interface ResourcesTabButtonProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+
+function ResourcesTabButton({ label, active, onClick }: ResourcesTabButtonProps) {
   return (
-    <>
-      <div>
-        <h1>Resources</h1>
-      </div>
-    </>
+    <Box as="button" flex={1} pb={2} cursor="pointer" onClick={onClick}>
+      <VStack gap={2}>
+        <Text fontSize="xl" fontWeight="bold" color="black">
+          {label}
+        </Text>
+        <Box h="4px" w="132px" borderRadius="full" bg={active ? "#4AAAF7" : "transparent"} />
+      </VStack>
+    </Box>
+  );
+}
+
+export default function Page() {
+  const [activeTab, setActiveTab] = useState<ResourcesTab>("discover");
+  const [query, setQuery] = useState("");
+  const [savedResourceIds, setSavedResourceIds] = useState<string[]>([
+    "energy-saving",
+    "shopping",
+    "waste-reduction",
+    "nature-preservation",
+  ]);
+
+  const visibleResources = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    if (!normalizedQuery) return EXAMPLE_RESOURCES;
+
+    return EXAMPLE_RESOURCES.filter((resource) => {
+      const searchableText = [resource.title, resource.description, ...resource.interestTags].join(" ").toLowerCase();
+
+      return searchableText.includes(normalizedQuery);
+    });
+  }, [query]);
+
+  const savedResources = visibleResources.filter((resource) => savedResourceIds.includes(resource.id));
+
+  const handleSave = (resourceId: string) => {
+    setSavedResourceIds((currentIds) => {
+      if (currentIds.includes(resourceId)) return currentIds;
+      return [...currentIds, resourceId];
+    });
+  };
+
+  const handleDelete = (resourceId: string) => {
+    setSavedResourceIds((currentIds) => currentIds.filter((id) => id !== resourceId));
+  };
+
+  const resourcesToShow = activeTab === "discover" ? visibleResources : savedResources;
+
+  return (
+    <Box minH="100vh" bg="#F9FAFB" px={6} pt={10} pb={28}>
+      <Box maxW="560px" mx="auto">
+        <HStack gap={4} mb={8}>
+          <HStack
+            flex={1}
+            h="74px"
+            bg="white"
+            borderRadius="full"
+            px={6}
+            boxShadow="0px 1px 8px rgba(89, 91, 98, 0.08)"
+            border="1px solid #EEF0F2"
+          >
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search"
+              border="none"
+              outline="none"
+              fontSize="lg"
+              _focusVisible={{ boxShadow: "none" }}
+            />
+            <LuSearch size={32} color="black" />
+          </HStack>
+
+          <Box
+            h="74px"
+            w="74px"
+            bg="white"
+            borderRadius="full"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            boxShadow="0px 1px 8px rgba(89, 91, 98, 0.08)"
+            border="1px solid #EEF0F2"
+          >
+            <LuBell size={30} color="black" />
+          </Box>
+        </HStack>
+
+        <HStack mb={6}>
+          <ResourcesTabButton
+            label="Discover"
+            active={activeTab === "discover"}
+            onClick={() => setActiveTab("discover")}
+          />
+          <ResourcesTabButton label="Saved" active={activeTab === "saved"} onClick={() => setActiveTab("saved")} />
+        </HStack>
+
+        {activeTab === "discover" && (
+          <Box
+            bg="#EAF4FB"
+            borderRadius="26px"
+            minH="234px"
+            px={8}
+            pb={8}
+            mb={8}
+            display="flex"
+            flexDirection="column"
+            justifyContent="flex-end"
+          >
+            <Text fontSize="3xl" fontWeight="bold" color="black" lineHeight="1.1">
+              Featured Resource
+            </Text>
+            <Text fontSize="md" color="black">
+              Resource Description
+            </Text>
+          </Box>
+        )}
+
+        <VStack align="stretch" gap={5}>
+          {resourcesToShow.map((resource) => (
+            <ResourceListCard
+              key={resource.id}
+              title={resource.title}
+              description={resource.description}
+              interestTags={resource.interestTags}
+              variant={activeTab}
+              onSave={() => handleSave(resource.id)}
+              onDelete={() => handleDelete(resource.id)}
+            />
+          ))}
+
+          {resourcesToShow.length === 0 && (
+            <Box
+              bg="white"
+              borderRadius="20px"
+              p={6}
+              textAlign="center"
+              boxShadow="0px 4px 18px rgba(89, 91, 98, 0.10)"
+            >
+              <Text fontWeight="semibold" color="black">
+                No resources found.
+              </Text>
+            </Box>
+          )}
+        </VStack>
+      </Box>
+    </Box>
   );
 }

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -114,10 +114,10 @@ export default function Page() {
         <Text fontSize="4xl" letterSpacing="-0.05em" whiteSpace="nowrap" fontWeight={"semibold"} pb={4}>
           Resources
         </Text>
-        <Box maxW="560px" mx="auto">
+        <Box w="full">
           <HStack
             mb={5}
-            flex={1}
+            w="full"
             h="56px"
             bg="white"
             borderRadius="full"

--- a/src/components/ResourceListCard.tsx
+++ b/src/components/ResourceListCard.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent } from "react";
+import { Box, HStack, Tag, Text, VStack } from "@chakra-ui/react";
+import { LuCheck, LuChevronRight, LuX } from "react-icons/lu";
+
+type ResourceCardVariant = "discover" | "saved";
+
+interface ResourceListCardProps {
+  title: string;
+  description: string;
+  interestTags: string[];
+  variant: ResourceCardVariant;
+  onSave?: () => void;
+  onDelete?: () => void;
+}
+
+const SWIPE_THRESHOLD = 80;
+const MAX_DRAG = 120;
+
+const TAG_STYLES: Record<string, { bg: string; color: string }> = {
+  "Energy Saving": { bg: "#64C9C2", color: "#273D3C" },
+  Shopping: { bg: "#4A86E8", color: "#1F2E47" },
+  "Waste Reduction": { bg: "#F5662E", color: "#3B2B25" },
+  "Nature Preservation & Restoration": { bg: "#51B94F", color: "#1F3B1F" },
+  Transportation: { bg: "#BE63EE", color: "#2F1D3B" },
+};
+
+const DEFAULT_TAG_STYLE = { bg: "#DDE5EC", color: "#2D3748" };
+
+export default function ResourceListCard({
+  title,
+  description,
+  interestTags,
+  variant,
+  onSave,
+  onDelete,
+}: ResourceListCardProps) {
+  const [dragX, setDragX] = useState(0);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const cardRef = useRef<HTMLDivElement>(null);
+  const startXRef = useRef<number | null>(null);
+  const startYRef = useRef<number | null>(null);
+  const dragXRef = useRef(0);
+  const isDraggingRef = useRef(false);
+  const isHorizontalSwipeRef = useRef<boolean | null>(null);
+
+  const getClientX = (e: ReactTouchEvent | ReactMouseEvent | MouseEvent) => {
+    if ("touches" in e) return e.touches[0].clientX;
+    return e.clientX;
+  };
+
+  const getClientY = (e: ReactTouchEvent | ReactMouseEvent | MouseEvent) => {
+    if ("touches" in e) return e.touches[0].clientY;
+    return e.clientY;
+  };
+
+  const handleStart = (e: ReactTouchEvent | ReactMouseEvent) => {
+    startXRef.current = getClientX(e);
+    startYRef.current = getClientY(e);
+    dragXRef.current = 0;
+    isDraggingRef.current = true;
+    isHorizontalSwipeRef.current = null;
+    setIsAnimating(false);
+  };
+
+  const handleMove = useCallback(
+    (e: ReactTouchEvent | ReactMouseEvent | MouseEvent) => {
+      if (!isDraggingRef.current || startXRef.current === null || startYRef.current === null) return;
+
+      const distX = getClientX(e) - startXRef.current;
+      const distY = getClientY(e) - startYRef.current;
+
+      if (isHorizontalSwipeRef.current === null && (Math.abs(distX) > 5 || Math.abs(distY) > 5)) {
+        isHorizontalSwipeRef.current = Math.abs(distX) > Math.abs(distY);
+      }
+
+      if (isHorizontalSwipeRef.current === false) return;
+
+      if (distX < 0) {
+        dragXRef.current = 0;
+        setDragX(0);
+        return;
+      }
+
+      const clamped = Math.max(Math.min(distX, MAX_DRAG), -MAX_DRAG);
+
+      dragXRef.current = clamped;
+      setDragX(clamped);
+    },
+    [variant],
+  );
+
+  const handleEnd = useCallback(() => {
+    if (!isDraggingRef.current) return;
+
+    isDraggingRef.current = false;
+    setIsAnimating(true);
+
+    if (variant === "discover" && dragXRef.current >= SWIPE_THRESHOLD) {
+      onSave?.();
+    }
+
+    if (variant === "saved" && dragXRef.current >= SWIPE_THRESHOLD) {
+      onDelete?.();
+    }
+
+    dragXRef.current = 0;
+    setDragX(0);
+  }, [onDelete, onSave, variant]);
+
+  useEffect(() => {
+    const onMouseMove = (e: MouseEvent) => handleMove(e);
+    const onMouseUp = () => handleEnd();
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+  }, [handleMove, handleEnd]);
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (isHorizontalSwipeRef.current === true) e.preventDefault();
+    };
+
+    el.addEventListener("touchmove", onTouchMove, { passive: false });
+
+    return () => el.removeEventListener("touchmove", onTouchMove);
+  }, []);
+
+  const isDeleteAction = variant === "saved";
+  const actionLabel = isDeleteAction ? "Delete" : "Save";
+  const revealColor = isDeleteAction ? "#B8BDC1" : "#ADEA9E";
+  const revealProgress = Math.min(Math.abs(dragX) / SWIPE_THRESHOLD, 1);
+  const isSwiping = dragX !== 0;
+  const revealSide = dragX < 0 ? "flex-end" : "flex-start";
+
+  return (
+    <Box position="relative" w="100%" overflowX="hidden" overflowY="visible" borderRadius="20px">
+      <Box
+        position="absolute"
+        inset={0}
+        bg={revealColor}
+        borderRadius="20px"
+        display="flex"
+        alignItems="center"
+        justifyContent={revealSide}
+        px="34px"
+        opacity={isSwiping ? revealProgress : 0}
+        transition={isSwiping ? "none" : "opacity 0.25s ease"}
+      >
+        <VStack gap={1}>
+          {isDeleteAction ? <LuX size={32} color="#3B3B3B" /> : <LuCheck size={34} color="#3B3B3B" />}
+
+          <Text fontSize="sm" fontWeight="semibold" color="#3B3B3B">
+            {actionLabel}
+          </Text>
+        </VStack>
+      </Box>
+
+      <Box
+        ref={cardRef}
+        bg="white"
+        borderRadius="20px"
+        px={4}
+        py={3}
+        minH="112px"
+        boxShadow="0px 4px 18px rgba(89, 91, 98, 0.10)"
+        transform={`translateX(${dragX}px)`}
+        transition={isAnimating ? "transform 0.25s ease" : "none"}
+        cursor={isDraggingRef.current ? "grabbing" : "grab"}
+        userSelect="none"
+        touchAction="pan-y"
+        onMouseDown={handleStart}
+        onTouchStart={handleStart}
+        onTouchMove={handleMove}
+        onTouchEnd={handleEnd}
+      >
+        <HStack align="flex-start" justify="space-between" gap={3}>
+          <VStack align="flex-start" gap={1} flex={1}>
+            <Text fontSize="xl" fontWeight="bold" lineHeight="1.1" color="black">
+              {title}
+            </Text>
+
+            <HStack gap={2} flexWrap="wrap">
+              {interestTags.map((tag) => {
+                const tagStyle = TAG_STYLES[tag] ?? DEFAULT_TAG_STYLE;
+
+                return (
+                  <Tag.Root key={tag} size="lg" bg={tagStyle.bg} borderRadius="full" px={4} py={1}>
+                    <Tag.Label color={tagStyle.color} fontWeight="semibold">
+                      {tag}
+                    </Tag.Label>
+                  </Tag.Root>
+                );
+              })}
+            </HStack>
+
+            <Text
+              fontSize="md"
+              color="black"
+              lineHeight="1.35"
+              css={
+                isExpanded
+                  ? undefined
+                  : {
+                      overflow: "hidden",
+                      display: "-webkit-box",
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: "vertical",
+                    }
+              }
+            >
+              {description}
+            </Text>
+          </VStack>
+
+          <Box
+            as="button"
+            aria-label={isExpanded ? "Collapse resource description" : "Expand resource description"}
+            aria-expanded={isExpanded}
+            color="black"
+            mt={1}
+            onClick={(event) => {
+              event.stopPropagation();
+              setIsExpanded((expanded) => !expanded);
+            }}
+            onMouseDown={(event) => event.stopPropagation()}
+            onTouchStart={(event) => event.stopPropagation()}
+          >
+            <Box transform={isExpanded ? "rotate(90deg)" : "rotate(0deg)"} transition="transform 0.2s ease">
+              <LuChevronRight size={24} />
+            </Box>
+          </Box>
+        </HStack>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Developer: Jonathan Lau

Closes #84

### Pull Request Summary

Made components for resource page. Swipe right on discover and they go to Saved. Swipe right on saved they delete!

### Modifications

{list out the files created/modified and a brief description of what was changed}

### Testing Considerations

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/70155214-49b5-46aa-b9fb-5e7b85fa2649" />

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/51460df2-0f0a-43ae-8cd3-875c496213fa" />
