### PR TITLE
 add user challenge fetching and home page challenge display

### DIFF
--- a/src/app/api/challenges/user/[userId]/route.ts
+++ b/src/app/api/challenges/user/[userId]/route.ts
@@ -1,21 +1,92 @@
 import { NextResponse } from "next/server";
-import ChallengeModel from "@/database/challengeSchema";
-import connectDB from "@/database/db";
 import { Types } from "mongoose";
+import ChallengeModel from "@/database/challengeSchema";
+import TaskModel from "@/database/taskSchema";
+import TaskAssignment from "@/database/taskAssignmentSchema";
+import connectDB from "@/database/db";
 
-export async function GET(req: Request, { params }: { params: { userId: string } }) {
+export async function GET(_req: Request, { params }: { params: { userId: string } }) {
   try {
     await connectDB();
 
     const { userId } = params;
 
+    if (!Types.ObjectId.isValid(userId)) {
+      return NextResponse.json({ error: "Invalid user id" }, { status: 400 });
+    }
+
+    const userObjectId = new Types.ObjectId(userId);
+
     const challenges = await ChallengeModel.find({
-      users: new Types.ObjectId(userId),
+      users: userObjectId,
+    }).lean();
+
+    if (!challenges.length) {
+      return NextResponse.json([], { status: 200 });
+    }
+
+    const allTaskIds = challenges.flatMap((challenge: any) => (challenge.task_ids || []).map((id: any) => String(id)));
+
+    const uniqueTaskIds = [...new Set(allTaskIds)].filter((id) => Types.ObjectId.isValid(id));
+
+    const tasks = await TaskModel.find({
+      _id: { $in: uniqueTaskIds },
+    }).lean();
+
+    const taskById = new Map(tasks.map((task: any) => [String(task._id), task]));
+
+    const assignments = await TaskAssignment.find({
+      user_id: userObjectId,
+      task_id: { $in: uniqueTaskIds },
+    })
+      .sort({ date: -1 })
+      .lean();
+
+    const latestAssignmentByTaskId = new Map<string, any>();
+
+    assignments.forEach((assignment: any) => {
+      const key = String(assignment.task_id);
+      if (!latestAssignmentByTaskId.has(key)) {
+        latestAssignmentByTaskId.set(key, assignment);
+      }
     });
 
-    return NextResponse.json(challenges, { status: 200 });
+    const response = challenges.map((challenge: any) => {
+      const tasksForChallenge = (challenge.task_ids || [])
+        .map((taskId: any) => {
+          const task = taskById.get(String(taskId));
+          if (!task) return null;
+
+          const assignment = latestAssignmentByTaskId.get(String(taskId));
+
+          return {
+            _id: String(task._id),
+            title: task.title,
+            description: task.description,
+            points: task.time ?? task.points ?? 0,
+            completed: assignment?.isComplete ?? false,
+            dueDate: assignment?.date ?? new Date().toISOString(),
+          };
+        })
+        .filter(Boolean);
+
+      const completedCount = tasksForChallenge.filter((task: any) => task.completed).length;
+      const completionPercentage =
+        tasksForChallenge.length === 0 ? 0 : Math.round((completedCount / tasksForChallenge.length) * 100);
+
+      return {
+        _id: String(challenge._id),
+        title: challenge.title,
+        task_ids: (challenge.task_ids || []).map((id: any) => String(id)),
+        users: (challenge.users || []).map((id: any) => String(id)),
+        tasks: tasksForChallenge,
+        completionPercentage,
+      };
+    });
+
+    return NextResponse.json(response, { status: 200 });
   } catch (error) {
-    console.error("GET /api/challenges/user error:", error);
+    console.error("GET /api/challenges/user/[userId] error:", error);
     return NextResponse.json({ error: "Server error" }, { status: 500 });
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -146,6 +146,7 @@ export default function Home() {
                   challenge={challenge}
                   tasks={challenge.tasks}
                   completionPercentage={challenge.completionPercentage}
+                  userId={userData ? String(userData._id) : undefined}
                 />
               ))}
             </VStack>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
+
 import { Box, IconButton, Text, VStack, HStack } from "@chakra-ui/react";
-import ProgressRing from "@/components/ProgressRing";
 import ChallengeComponent, { ChallengeSummary, ChallengeTask } from "@/components/ChallengeComponent";
 import { LuChevronLeft, LuChevronRight, LuBell } from "react-icons/lu";
 import Link from "next/link";
@@ -11,9 +11,15 @@ import { IUsers } from "@/database/userSchema";
 import { useRouter } from "next/navigation";
 import StreakCard from "@/components/StreakCard";
 
+type HydratedChallenge = ChallengeSummary & {
+  tasks: ChallengeTask[];
+  completionPercentage: number;
+};
+
 export default function Home() {
   const { isSignedIn, user, isLoaded } = useUser();
   const [userData, setUserData] = useState<IUsers | null>(null);
+  const [challenges, setChallenges] = useState<HydratedChallenge[]>([]);
 
   const router = useRouter();
 
@@ -39,6 +45,7 @@ export default function Home() {
           setUserData(null);
           return;
         }
+
         const userObj: IUsers = await res.json();
         setUserData(userObj);
 
@@ -68,12 +75,40 @@ export default function Home() {
         console.log("user is signed in!");
       }
     };
-    if (!isLoaded) {
-      return;
-    }
-    // get user
+
+    if (!isLoaded) return;
     getUser();
   }, [isLoaded, isSignedIn, user]);
+
+  useEffect(() => {
+    const getChallenges = async () => {
+      if (!userData?._id) {
+        setChallenges([]);
+        return;
+      }
+
+      try {
+        const res = await fetch(`/api/challenges/user/${userData._id}`, {
+          method: "GET",
+          headers: { "Content-Type": "application/json" },
+        });
+
+        if (!res.ok) {
+          setChallenges([]);
+          return;
+        }
+
+        const challengeData: HydratedChallenge[] = await res.json();
+        console.log("challengeData", challengeData);
+        setChallenges(challengeData);
+      } catch (error) {
+        console.error(error);
+        setChallenges([]);
+      }
+    };
+
+    getChallenges();
+  }, [userData?._id]);
 
   return (
     <main>
@@ -87,22 +122,35 @@ export default function Home() {
               <LuBell size={24} />
             </Link>
           </HStack>
-          {/* Progress Ring */}
+
           <VStack w={"full"} gap={5} py={"20px"}>
             <HStack w={"full"} justifyContent={"space-between"}>
-              <IconButton area-label="Previous Progress Ring" variant={"ghost"}>
+              <IconButton aria-label="Previous Progress Ring" variant={"ghost"}>
                 <LuChevronLeft />
               </IconButton>
               <Text fontSize={"x-large"} fontWeight={"semibold"}>
                 Today
               </Text>
-              <IconButton area-label="Next Progress Ring" variant={"ghost"}>
+              <IconButton aria-label="Next Progress Ring" variant={"ghost"}>
                 <LuChevronRight />
               </IconButton>
             </HStack>
-            <StreakCard></StreakCard>
+            <StreakCard />
           </VStack>
-          {/* Tasks */}
+
+          {challenges.length > 0 && (
+            <VStack w="full" align="stretch" gap={3}>
+              {challenges.map((challenge) => (
+                <ChallengeComponent
+                  key={challenge._id}
+                  challenge={challenge}
+                  tasks={challenge.tasks}
+                  completionPercentage={challenge.completionPercentage}
+                />
+              ))}
+            </VStack>
+          )}
+
           <TaskList userId={userData ? String(userData._id) : undefined} />
         </VStack>
       </Box>

--- a/src/components/ChallengeComponent.tsx
+++ b/src/components/ChallengeComponent.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Collapsible, Progress, Text } from "@chakra-ui/react";
 import TaskCard from "@/components/TaskCard";
 import Style from "@/styles/ChallengeComponent.module.css";
+import SwipeableTaskCard from "./SwipeableTaskCard";
 
 export type ChallengeTask = {
   _id: string;
@@ -24,6 +25,7 @@ interface ChallengeComponentProps {
   tasks: ChallengeTask[];
   completionPercentage: number;
   defaultOpen?: boolean;
+  userId?: string;
 }
 
 export default function ChallengeComponent({
@@ -31,8 +33,58 @@ export default function ChallengeComponent({
   tasks,
   completionPercentage,
   defaultOpen = false,
+  userId,
 }: ChallengeComponentProps) {
   const safeCompletion = Math.min(100, Math.max(0, completionPercentage));
+  const [localTasks, setLocalTasks] = useState(tasks);
+
+  useEffect(() => {
+    setLocalTasks(tasks);
+  }, [tasks]);
+
+  const updateCompletion = async (taskId: string, completed: boolean) => {
+    if (!userId) return;
+
+    let previousCompleted: boolean | undefined;
+
+    setLocalTasks((prev) =>
+      prev.map((t) => {
+        if (t._id === taskId) {
+          previousCompleted = t.completed;
+          if (t.completed === completed) return t;
+          return { ...t, completed };
+        }
+        return t;
+      }),
+    );
+    // const previousCompleted = task.completed;
+    // setTask((prev) => (prev ? { ...prev, completed } : prev));
+
+    try {
+      // TODO: make API route that gets taskAssignments based on userId and challengeId
+      /*
+      const res = await fetch(`/api/taskAssignment/${userId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isComplete: completed }),
+      });
+      
+
+      if (!res.ok) throw new Error("Failed to update task completion");
+      */
+    } catch (error) {
+      console.error("Failed to update completion:", error);
+      // setTask((prev) => (prev ? { ...prev, completed: previousCompleted } : prev));
+    }
+  };
+
+  const markComplete = (task: ChallengeTask) => {
+    updateCompletion(task._id, true);
+  };
+
+  const markIncomplete = (task: ChallengeTask) => {
+    updateCompletion(task._id, false);
+  };
 
   return (
     <Collapsible.Root defaultOpen={defaultOpen} className={Style.challengeContainer}>
@@ -53,14 +105,16 @@ export default function ChallengeComponent({
 
       <Collapsible.Content>
         <div className={Style.challengeTasks}>
-          {tasks.map((task) => (
-            <TaskCard
+          {localTasks.map((task) => (
+            <SwipeableTaskCard
               key={task._id}
               date={new Date(task.dueDate)}
               title={task.title}
               description={task.description}
               minEstimate={task.points}
               completed={task.completed}
+              onSwipeRight={() => markComplete(task)}
+              onSwipeLeft={() => markIncomplete(task)}
             />
           ))}
         </div>

--- a/src/components/SwipeableTaskCard.tsx
+++ b/src/components/SwipeableTaskCard.tsx
@@ -119,7 +119,7 @@ export default function SwipeableTaskCard({
     const el = cardRef.current;
     if (!el) return;
     const onTouchMove = (e: TouchEvent) => {
-      if (isHorizontalSwipeRef.current === true) e.preventDefault();
+      if (isHorizontalSwipeRef.current === true || e.cancelable) e.preventDefault();
     };
     el.addEventListener("touchmove", onTouchMove, { passive: false });
     return () => el.removeEventListener("touchmove", onTouchMove);


### PR DESCRIPTION
## Developer: Anthony Mendoza

Closes #74 

### Pull Request Summary

Added challenge data fetching to the home page using the user challenge API route and displays challenge cards with their tasks and completion percentage. Also updated the challenge user route to return hydrated challenge data including task details and completion state for the signed-in user.

### Modifications

{list out the files created/modified and a brief description of what was changed}

### Testing Considerations

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="394" height="859" alt="challenges-100%" src="https://github.com/user-attachments/assets/7154488f-cc83-4ea5-897a-ba260e22de6d" />
<img width="397" height="848" alt="Challenge-50%" src="https://github.com/user-attachments/assets/ed5a08a0-25f2-4132-9fba-edfa04bb08e6" />

