### PR TITLE
Fix/challenge task assignment routes

### DIFF
--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -27,6 +27,7 @@ export async function GET(req: NextRequest) {
 
     const taskAssignments = await TaskAssignment.find({
       user_id: userId,
+      challenge_id: { $exists: false },
       date: { $gte: startDate, $lt: endDate },
     })
       .select("_id task_id date isComplete")

--- a/src/app/api/challenges/[challengeId]/route.ts
+++ b/src/app/api/challenges/[challengeId]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
+import TaskAssignment from "@/database/taskAssignmentSchema";
 import ChallengeModel from "@/database/challengeSchema";
 import connectDB from "@/database/db";
+import { syncChallengeTaskAssignments, toUniqueObjectIdStrings } from "@/lib/challengeTaskAssignments";
 
 export async function PATCH(req: Request, { params }: { params: { challengeId: string } }) {
   try {
@@ -9,11 +11,20 @@ export async function PATCH(req: Request, { params }: { params: { challengeId: s
     const { challengeId } = params;
     const body = await req.json();
 
-    const updatedChallenge = await ChallengeModel.findByIdAndUpdate(challengeId, body, { new: true });
+    const updatedChallenge = await ChallengeModel.findByIdAndUpdate(challengeId, body, {
+      new: true,
+      runValidators: true,
+    });
 
     if (!updatedChallenge) {
       return NextResponse.json({ error: "Challenge not found" }, { status: 404 });
     }
+
+    await syncChallengeTaskAssignments({
+      challengeId,
+      userIds: toUniqueObjectIdStrings(updatedChallenge.users ?? []),
+      taskIds: toUniqueObjectIdStrings(updatedChallenge.task_ids ?? []),
+    });
 
     return NextResponse.json(updatedChallenge, { status: 200 });
   } catch (error) {
@@ -33,6 +44,8 @@ export async function DELETE(req: Request, { params }: { params: { challengeId: 
     if (!deleted) {
       return NextResponse.json({ error: "Challenge not found" }, { status: 404 });
     }
+
+    await TaskAssignment.deleteMany({ challenge_id: challengeId });
 
     return NextResponse.json({ message: "Challenge deleted successfully" }, { status: 200 });
   } catch (error) {

--- a/src/app/api/challenges/route.ts
+++ b/src/app/api/challenges/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import ChallengeModel from "@/database/challengeSchema";
 import connectDB from "@/database/db";
+import { syncChallengeTaskAssignments, toUniqueObjectIdStrings } from "@/lib/challengeTaskAssignments";
 
 export async function GET() {
   try {
@@ -24,6 +25,12 @@ export async function POST(req: Request) {
     const challenge = await req.json();
 
     const newChallenge = await ChallengeModel.create(challenge);
+
+    await syncChallengeTaskAssignments({
+      challengeId: newChallenge._id.toString(),
+      userIds: toUniqueObjectIdStrings(newChallenge.users ?? []),
+      taskIds: toUniqueObjectIdStrings(newChallenge.task_ids ?? []),
+    });
 
     return NextResponse.json(newChallenge, { status: 201 });
   } catch (error) {

--- a/src/app/api/challenges/user/[userId]/route.ts
+++ b/src/app/api/challenges/user/[userId]/route.ts
@@ -25,6 +25,7 @@ export async function GET(_req: Request, { params }: { params: { userId: string 
       return NextResponse.json([], { status: 200 });
     }
 
+    const challengeIds = challenges.map((challenge: any) => String(challenge._id));
     const allTaskIds = challenges.flatMap((challenge: any) => (challenge.task_ids || []).map((id: any) => String(id)));
 
     const uniqueTaskIds = [...new Set(allTaskIds)].filter((id) => Types.ObjectId.isValid(id));
@@ -37,19 +38,16 @@ export async function GET(_req: Request, { params }: { params: { userId: string 
 
     const assignments = await TaskAssignment.find({
       user_id: userObjectId,
+      challenge_id: { $in: challengeIds },
       task_id: { $in: uniqueTaskIds },
-    })
-      .sort({ date: -1 })
-      .lean();
+    }).lean();
 
-    const latestAssignmentByTaskId = new Map<string, any>();
-
-    assignments.forEach((assignment: any) => {
-      const key = String(assignment.task_id);
-      if (!latestAssignmentByTaskId.has(key)) {
-        latestAssignmentByTaskId.set(key, assignment);
-      }
-    });
+    const assignmentByChallengeTaskKey = new Map<string, any>(
+      assignments.map((assignment: any) => [
+        `${String(assignment.challenge_id)}:${String(assignment.task_id)}`,
+        assignment,
+      ]),
+    );
 
     const response = challenges.map((challenge: any) => {
       const tasksForChallenge = (challenge.task_ids || [])
@@ -57,9 +55,10 @@ export async function GET(_req: Request, { params }: { params: { userId: string 
           const task = taskById.get(String(taskId));
           if (!task) return null;
 
-          const assignment = latestAssignmentByTaskId.get(String(taskId));
+          const assignment = assignmentByChallengeTaskKey.get(`${String(challenge._id)}:${String(taskId)}`);
 
           return {
+            assignmentId: assignment?._id ? String(assignment._id) : "",
             _id: String(task._id),
             title: task.title,
             description: task.description,

--- a/src/app/api/taskAssignment/[userId]/route.ts
+++ b/src/app/api/taskAssignment/[userId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Types } from "mongoose";
 import connectDB from "@/database/db";
 import TaskAssignment from "@/database/taskAssignmentSchema";
 import User from "@/database/userSchema";
@@ -30,7 +31,26 @@ export async function GET(req: NextRequest, { params }: { params: { userId: stri
   try {
     await connectDB();
 
+    if (!Types.ObjectId.isValid(params.userId)) {
+      return NextResponse.json({ error: "Invalid user id" }, { status: 400 });
+    }
+
     const { searchParams } = new URL(req.url);
+    const challengeId = searchParams.get("challengeId");
+
+    if (challengeId) {
+      if (!Types.ObjectId.isValid(challengeId)) {
+        return NextResponse.json({ error: "Invalid challenge id" }, { status: 400 });
+      }
+
+      const challengeAssignments = await TaskAssignment.find({
+        user_id: params.userId,
+        challenge_id: challengeId,
+      }).sort({ _id: 1 });
+
+      return NextResponse.json(challengeAssignments, { status: 200 });
+    }
+
     const dateParam = searchParams.get("date");
     const range = searchParams.get("range") ?? "day";
     const baseDate = dateParam ? new Date(dateParam) : new Date();
@@ -41,6 +61,7 @@ export async function GET(req: NextRequest, { params }: { params: { userId: stri
 
     const taskAssignment = await TaskAssignment.find({
       user_id: params.userId,
+      challenge_id: { $exists: false },
       date: { $gte: startDate, $lt: endDate },
     }).sort({ date: 1 });
 
@@ -74,6 +95,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { userId: st
 
           return {
             user_id: params.userId,
+            challenge_id: { $exists: false },
             date: { $gte: today, $lt: tomorrow },
           };
         })();
@@ -120,6 +142,7 @@ export async function DELETE(req: NextRequest, { params }: { params: { userId: s
 
     const deleted = await TaskAssignment.findOneAndDelete({
       user_id: params.userId,
+      challenge_id: { $exists: false },
       date: { $gte: today, $lt: tomorrow },
     });
 

--- a/src/app/api/taskAssignment/challenge/route.ts
+++ b/src/app/api/taskAssignment/challenge/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Types } from "mongoose";
+import ChallengeModel from "@/database/challengeSchema";
+import connectDB from "@/database/db";
+import { toUniqueObjectIdStrings, upsertChallengeTaskAssignments } from "@/lib/challengeTaskAssignments";
+
+type ChallengeMembersAndTasks = {
+  users?: unknown[];
+  task_ids?: unknown[];
+};
+
+export async function POST(req: NextRequest) {
+  try {
+    await connectDB();
+
+    const body = await req.json();
+    const challengeId = typeof body.challengeId === "string" ? body.challengeId : "";
+
+    if (!Types.ObjectId.isValid(challengeId)) {
+      return NextResponse.json({ error: "Invalid challenge id" }, { status: 400 });
+    }
+
+    const challenge = (await ChallengeModel.findById(challengeId)
+      .select("users task_ids")
+      .lean()) as ChallengeMembersAndTasks | null;
+
+    if (!challenge) {
+      return NextResponse.json({ error: "Challenge not found" }, { status: 404 });
+    }
+
+    const challengeUserIds = toUniqueObjectIdStrings(challenge.users ?? []);
+    const challengeTaskIds = toUniqueObjectIdStrings(challenge.task_ids ?? []);
+    const userIds = Array.isArray(body.userIds) ? toUniqueObjectIdStrings(body.userIds) : challengeUserIds;
+    const taskIds = Array.isArray(body.taskIds) ? toUniqueObjectIdStrings(body.taskIds) : challengeTaskIds;
+
+    const hasInvalidUserIds = userIds.some((userId) => !challengeUserIds.includes(userId));
+    if (hasInvalidUserIds) {
+      return NextResponse.json({ error: "One or more user ids are not part of the challenge" }, { status: 400 });
+    }
+
+    const hasInvalidTaskIds = taskIds.some((taskId) => !challengeTaskIds.includes(taskId));
+    if (hasInvalidTaskIds) {
+      return NextResponse.json({ error: "One or more task ids are not part of the challenge" }, { status: 400 });
+    }
+
+    const result = await upsertChallengeTaskAssignments({
+      challengeId,
+      userIds,
+      taskIds,
+    });
+
+    return NextResponse.json(
+      {
+        challengeId,
+        userIds,
+        taskIds,
+        ...result,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("POST /api/taskAssignment/challenge error:", error);
+    return NextResponse.json({ error: "Failed to create challenge task assignments" }, { status: 500 });
+  }
+}

--- a/src/components/ChallengeComponent.tsx
+++ b/src/components/ChallengeComponent.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { Collapsible, Progress, Text } from "@chakra-ui/react";
-import TaskCard from "@/components/TaskCard";
 import Style from "@/styles/ChallengeComponent.module.css";
 import SwipeableTaskCard from "./SwipeableTaskCard";
 
 export type ChallengeTask = {
+  assignmentId?: string;
   _id: string;
   title: string;
   description: string;
@@ -35,55 +35,59 @@ export default function ChallengeComponent({
   defaultOpen = false,
   userId,
 }: ChallengeComponentProps) {
-  const safeCompletion = Math.min(100, Math.max(0, completionPercentage));
   const [localTasks, setLocalTasks] = useState(tasks);
+  const localCompletionPercentage =
+    localTasks.length === 0
+      ? completionPercentage
+      : Math.round((localTasks.filter((task) => task.completed).length / localTasks.length) * 100);
+  const safeCompletion = Math.min(100, Math.max(0, localCompletionPercentage));
 
   useEffect(() => {
     setLocalTasks(tasks);
   }, [tasks]);
 
-  const updateCompletion = async (taskId: string, completed: boolean) => {
+  const updateCompletion = async (taskId: string, assignmentId: string | undefined, completed: boolean) => {
     if (!userId) return;
 
-    let previousCompleted: boolean | undefined;
+    const previousTasks = localTasks;
 
     setLocalTasks((prev) =>
       prev.map((t) => {
         if (t._id === taskId) {
-          previousCompleted = t.completed;
           if (t.completed === completed) return t;
           return { ...t, completed };
         }
         return t;
       }),
     );
-    // const previousCompleted = task.completed;
-    // setTask((prev) => (prev ? { ...prev, completed } : prev));
 
     try {
-      // TODO: make API route that gets taskAssignments based on userId and challengeId
-      /*
+      if (!assignmentId) {
+        throw new Error("Missing challenge assignment id");
+      }
+
       const res = await fetch(`/api/taskAssignment/${userId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ isComplete: completed }),
+        body: JSON.stringify({
+          assignmentId,
+          isComplete: completed,
+        }),
       });
-      
 
       if (!res.ok) throw new Error("Failed to update task completion");
-      */
     } catch (error) {
       console.error("Failed to update completion:", error);
-      // setTask((prev) => (prev ? { ...prev, completed: previousCompleted } : prev));
+      setLocalTasks(previousTasks);
     }
   };
 
   const markComplete = (task: ChallengeTask) => {
-    updateCompletion(task._id, true);
+    updateCompletion(task._id, task.assignmentId, true);
   };
 
   const markIncomplete = (task: ChallengeTask) => {
-    updateCompletion(task._id, false);
+    updateCompletion(task._id, task.assignmentId, false);
   };
 
   return (

--- a/src/database/taskAssignmentSchema.ts
+++ b/src/database/taskAssignmentSchema.ts
@@ -4,7 +4,8 @@ export type ITaskAssignment = {
   _id: Types.ObjectId;
   user_id: Types.ObjectId;
   task_id: Types.ObjectId;
-  date: Date;
+  challenge_id?: Types.ObjectId;
+  date?: Date;
   isComplete: boolean;
 };
 
@@ -20,9 +21,12 @@ const taskAssignmentSchema = new Schema(
       ref: "Task",
       required: true,
     },
+    challenge_id: {
+      type: Schema.Types.ObjectId,
+      ref: "Challenge",
+    },
     date: {
       type: Date,
-      required: true,
     },
     isComplete: {
       type: Boolean,
@@ -31,6 +35,16 @@ const taskAssignmentSchema = new Schema(
   },
   {
     collection: "devtaskassignments",
+  },
+);
+
+taskAssignmentSchema.index(
+  { challenge_id: 1, user_id: 1, task_id: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      challenge_id: { $exists: true },
+    },
   },
 );
 

--- a/src/lib/challengeTaskAssignments.ts
+++ b/src/lib/challengeTaskAssignments.ts
@@ -1,0 +1,89 @@
+import { Types } from "mongoose";
+import TaskAssignment from "@/database/taskAssignmentSchema";
+
+type ChallengeAssignmentSyncInput = {
+  challengeId: string;
+  userIds: string[];
+  taskIds: string[];
+};
+
+const toObjectIdString = (value: unknown) => {
+  if (typeof value === "string" && Types.ObjectId.isValid(value)) {
+    return value;
+  }
+
+  if (value instanceof Types.ObjectId) {
+    return value.toString();
+  }
+
+  return null;
+};
+
+export const toUniqueObjectIdStrings = (values: unknown) => {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  return [...new Set(values.map(toObjectIdString).filter((value): value is string => value !== null))];
+};
+
+const toObjectIds = (ids: string[]) => ids.map((id) => new Types.ObjectId(id));
+
+const buildUpsertOperations = ({ challengeId, userIds, taskIds }: ChallengeAssignmentSyncInput) => {
+  const challengeObjectId = new Types.ObjectId(challengeId);
+
+  return userIds.flatMap((userId) =>
+    taskIds.map((taskId) => ({
+      updateOne: {
+        filter: {
+          challenge_id: challengeObjectId,
+          user_id: new Types.ObjectId(userId),
+          task_id: new Types.ObjectId(taskId),
+        },
+        update: {
+          $setOnInsert: {
+            challenge_id: challengeObjectId,
+            user_id: new Types.ObjectId(userId),
+            task_id: new Types.ObjectId(taskId),
+            isComplete: false,
+          },
+        },
+        upsert: true,
+      },
+    })),
+  );
+};
+
+export const upsertChallengeTaskAssignments = async ({
+  challengeId,
+  userIds,
+  taskIds,
+}: ChallengeAssignmentSyncInput) => {
+  if (!userIds.length || !taskIds.length) {
+    return { assignmentPairs: 0 };
+  }
+
+  const operations = buildUpsertOperations({ challengeId, userIds, taskIds });
+
+  if (operations.length > 0) {
+    await TaskAssignment.bulkWrite(operations, { ordered: false });
+  }
+
+  return { assignmentPairs: operations.length };
+};
+
+export const syncChallengeTaskAssignments = async ({ challengeId, userIds, taskIds }: ChallengeAssignmentSyncInput) => {
+  const challengeObjectId = new Types.ObjectId(challengeId);
+
+  if (!userIds.length || !taskIds.length) {
+    await TaskAssignment.deleteMany({ challenge_id: challengeObjectId });
+    return { assignmentPairs: 0 };
+  }
+
+  await TaskAssignment.deleteMany({
+    challenge_id: challengeObjectId,
+    $or: [{ user_id: { $nin: toObjectIds(userIds) } }, { task_id: { $nin: toObjectIds(taskIds) } }],
+  });
+
+  return upsertChallengeTaskAssignments({ challengeId, userIds, taskIds });
+};


### PR DESCRIPTION
## Developer: Daniel Erazo

Closes #93

### Pull Request Summary

This PR adds backend support for challenge task assignments.

It creates task assignments when users or tasks are added to a challenge, adds a route to get a user's task assignments for a specific challenge, and keeps challenge assignments separate from the normal daily/calendar task assignment flow.

### Modifications

- added challenge-based task assignment support to the schema
- added helper logic to bulk create and sync challenge task assignments
- added a new challenge task assignment API route
- updated challenge create/update/delete routes to keep task assignments in sync
- updated user challenge data to return the correct assignment state
- updated the challenge component to use assignment IDs when marking tasks complete

### Testing Considerations

- ran eslint on the changed files
- verified the branch includes the new route and challenge sync logic

Reviewer can verify by:
- creating a challenge with users and tasks
- confirming challenge task assignments are created
- confirming `GET /api/taskAssignment/[userId]?challengeId=<challengeId>` returns the expected assignments
- confirming daily/calendar task routes do not include challenge assignments

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

N/A

