### PR TITLE
changes to hide page's contents until user status is known?

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -110,6 +110,9 @@ export default function Home() {
     getChallenges();
   }, [userData?._id]);
 
+  if (!isLoaded || !isSignedIn) {
+    return null;
+  }
   return (
     <main>
       <Box display={"flex"} justifyContent={"center"}>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -3,12 +3,16 @@
 import type { ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import Navbar from "@/components/Navbar";
+import { useAuth } from "@clerk/nextjs";
 
 const HIDE_NAVBAR_ROUTES = ["/login", "/sign-up"];
 
 export default function AppShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
-  const showNavbar = !HIDE_NAVBAR_ROUTES.some((route) => pathname === route || pathname.startsWith(`${route}/`));
+  const { isLoaded, isSignedIn } = useAuth();
+  const hideByRoute = HIDE_NAVBAR_ROUTES.some((route) => pathname === route || pathname.startsWith(`${route}/`));
+
+  const showNavbar = isLoaded && isSignedIn && !hideByRoute;
 
   return (
     <div style={{ minHeight: "100vh", paddingBottom: showNavbar ? "120px" : "0" }}>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,16 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+const isProtectedRoute = createRouteMatcher(["/"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) {
+    const loginUrl = new URL("/login", req.url);
+
+    await auth.protect({
+      unauthenticatedUrl: loginUrl.toString(),
+    });
+  }
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
Upon opening a page before data is loaded, the page is empty instead of some default content.

Also, Clerk is used to redirect to sign up/login page.

Navbar is also adjusted to be hidden until user status is known to be signed in user. 