### PR TITLE
Fix admin card title alignment

### DIFF
--- a/src/components/AdminChallengeCard.tsx
+++ b/src/components/AdminChallengeCard.tsx
@@ -21,9 +21,18 @@ export default function AdminChallengeCard({ title, description, isActive }: Adm
       >
         {/* Header */}
         <HStack h="100%" w="100%" align="flex-start" gap={2}>
-          <Collapsible.Trigger transition="transform 0.2s" flex="1" w="100%">
-            <VStack align="flex-start" gap={0} w="100%">
-              <Text fontSize="lg" fontWeight="semibold">
+          <Collapsible.Trigger transition="transform 0.2s" flex="1" minW={0} w="100%" textAlign="left">
+            <VStack align="flex-start" gap={0} minW={0} w="100%">
+              <Text
+                fontSize="lg"
+                fontWeight="semibold"
+                w="100%"
+                textAlign="left"
+                whiteSpace="normal"
+                overflowWrap="anywhere"
+                wordBreak="break-word"
+                lineHeight="1.25"
+              >
                 {title}
               </Text>
               <Text fontSize="sm" color={isActive ? "#ADEA9E" : "#EA9E9E"}>

--- a/src/components/AdminResourceCard.tsx
+++ b/src/components/AdminResourceCard.tsx
@@ -43,10 +43,19 @@ export default function AdminResourceCard({
   };
 
   return (
-    <Box bg="white" borderRadius="xl" p={4} shadow="sm">
-      <HStack align="flex-start" justify="space-between" gap={3}>
-        <VStack align="stretch" gap={2} flex={1}>
-          <Text fontWeight="bold" fontSize="lg">
+    <Box bg="white" borderRadius="xl" p={4} shadow="sm" w="100%">
+      <HStack align="flex-start" justify="space-between" gap={3} w="100%">
+        <VStack align="stretch" gap={2} flex={1} minW={0}>
+          <Text
+            fontWeight="bold"
+            fontSize="lg"
+            w="100%"
+            textAlign="left"
+            whiteSpace="normal"
+            overflowWrap="anywhere"
+            wordBreak="break-word"
+            lineHeight="1.25"
+          >
             {title}
           </Text>
 

--- a/src/components/AdminTaskCard.tsx
+++ b/src/components/AdminTaskCard.tsx
@@ -54,9 +54,18 @@ export default function AdminTaskCard({
         boxShadow="0px 1px 8px rgba(89, 91, 98, 0.1)"
       >
         <HStack h="100%" w="100%" align="flex-start" gap={2}>
-          <Collapsible.Trigger transition="transform 0.2s" flex="1" w="100%">
-            <VStack align="flex-start" gap={0} w="100%">
-              <Text fontSize="lg" fontWeight="semibold">
+          <Collapsible.Trigger transition="transform 0.2s" flex="1" minW={0} w="100%" textAlign="left">
+            <VStack align="flex-start" gap={0} minW={0} w="100%">
+              <Text
+                fontSize="lg"
+                fontWeight="semibold"
+                w="100%"
+                textAlign="left"
+                whiteSpace="normal"
+                overflowWrap="anywhere"
+                wordBreak="break-word"
+                lineHeight="1.25"
+              >
                 {title}
               </Text>
 


### PR DESCRIPTION
## Developer: Jonathan Lau

Closes #129 

### Pull Request Summary

Fixed the alignment issue, where long titles in challenges, tasks, and resources would go to center and not left. 

### Modifications

{list out the files created/modified and a brief description of what was changed}

### Testing Considerations

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="364" height="175" alt="image" src="https://github.com/user-attachments/assets/3c82bfd4-1ef3-4d2d-a5f8-d579db08495f" />
