### PR TITLE
fix: protect admin routes using MongoDB role

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { useRequireAdmin } from "@/lib/hooks/page-protections";
+import { Box, Spinner } from "@chakra-ui/react";
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const isAuthorized = useRequireAdmin();
+
+  if (!isAuthorized) {
+    return (
+      <Box display="flex" justifyContent="center" pt={20}>
+        <Spinner />
+      </Box>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -22,9 +22,7 @@ export default function Page() {
   const [userData, setUserData] = useState<IUsers | null>(null);
 
   // commented out for development
-  // const isAdmin = user?.publicMetadata?.role === "admin";
-  const isAdmin = true;
-
+  const [isAdmin, setIsAdmin] = useState(false);
   // load profile picture
   useEffect(() => {
     const getUser = async () => {
@@ -38,8 +36,9 @@ export default function Page() {
         if (!res.ok) {
           return;
         }
-
         const userObj = await res.json();
+        const role = userObj?.role ?? (Array.isArray(userObj) ? userObj[0]?.role : null);
+        setIsAdmin(role !== "user" && role != null);
         setUserData(Array.isArray(userObj) ? (userObj[0] ?? null) : userObj);
       }
     };

--- a/src/lib/hooks/page-protections.ts
+++ b/src/lib/hooks/page-protections.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+
+export function useRequireAdmin() {
+  const { isLoaded, isSignedIn, user } = useUser();
+  const router = useRouter();
+  const [isAuthorized, setIsAuthorized] = useState(false);
+
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (!isSignedIn) {
+      router.replace("/");
+      return;
+    }
+
+    const check = async () => {
+      const email = encodeURIComponent(user.emailAddresses[0].emailAddress);
+      const res = await fetch(`/api/user/email/${email}`);
+      if (!res.ok) {
+        router.replace("/");
+        return;
+      }
+
+      const userObj = await res.json();
+      const mongoUser = Array.isArray(userObj) ? userObj[0] : userObj;
+      if (!mongoUser?.role || mongoUser.role === "user") {
+        router.replace("/");
+      } else {
+        setIsAuthorized(true);
+      }
+    };
+
+    check();
+  }, [isLoaded, isSignedIn, user, router]);
+
+  return isAuthorized;
+}


### PR DESCRIPTION
## Developer: Victor Herrera
Closes #131 

### Pull Request Summary

protect admin routes using MongoDB role field instead of hardcoded value.

### Modifications

profile/page.tsx - hide admin tab for non-admins
app/admin/layout.tsx - redirect non-admins away from all /admin/* routes
app/admin/page.tsx - removed duplicate auth logic
hooks/useRequireAdmin.ts - reusable admin check hook

### Testing Considerations

Non-admin users cannot see admin tab in profile
Navigating to /admin/* redirects non-admins to home

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

https://drive.google.com/file/d/1XdRdotnZbAal3LECtJGoD2V5UeW8IZRr/view?usp=sharing

https://drive.google.com/file/d/1kDJPmYZSEwxiqHrrULmlr1J8O7njVpXW/view?usp=sharing