### PR TITLE
feat: add edit and delete functionality to admin challenge cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -271,6 +271,7 @@
       "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-3.32.0.tgz",
       "integrity": "sha512-moQcmm75vm4i4IYxaRhN+49hGsQSHyB4NU84UsNjLf/XMDcg3RQzOlRfbmYp4DT7ojAtvqZld6aY6jGLikSp8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ark-ui/react": "^5.29.1",
         "@emotion/is-prop-valid": "^1.4.0",
@@ -446,6 +447,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -655,6 +657,7 @@
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.10.0.tgz",
       "integrity": "sha512-oxDR/NTEJ1k+UFVQElaNIk65E/Z83HK1z1WI3lQyhTtnNg4R5oVXaPzK3jcpKG8UHKDVuDQHzn+wsxSz8RP3aw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -1128,6 +1131,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.10.0.tgz",
       "integrity": "sha512-E24l90SxuJhytWJ0pTQydFT46Nk0Z+bsLKo/L8rtQSL93rQ6byd1V/QbDpHUTdLPOMsBCcYXZweADNCfOCmOAg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.10.0",
         "@typescript-eslint/types": "8.10.0",
@@ -2212,6 +2216,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
       "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3246,6 +3251,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3328,6 +3334,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3421,6 +3428,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -5550,6 +5558,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
       "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -6002,6 +6011,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6082,6 +6092,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6093,6 +6104,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7050,6 +7062,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/admin/manage-challenges/new-challenge/page.tsx
+++ b/src/app/admin/manage-challenges/new-challenge/page.tsx
@@ -43,9 +43,90 @@ function NewChallengeForm() {
   const [tasksError, setTasksError] = useState("");
   const [taskSearch, setTaskSearch] = useState("");
   const [selectedTaskIds, setSelectedTaskIds] = useState<string[]>([]);
+  const [pendingTaskIds, setPendingTaskIds] = useState<string[] | null>(null); // holds ids until tasks load
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const challengeId = searchParams.get("challengeId");
+  const isEditMode = Boolean(challengeId);
 
   const visibleTags = showAllTags ? AVAILABLE_TAGS : AVAILABLE_TAGS.slice(0, 5);
   const hiddenCount = AVAILABLE_TAGS.length - 5;
+
+  // Fetch all available tasks first
+  useEffect(() => {
+    const fetchTasks = async () => {
+      setTasksLoading(true);
+      setTasksError("");
+      try {
+        const res = await fetch("/api/task", { cache: "no-store" });
+        if (!res.ok) throw new Error("Failed to load tasks");
+        const data: TaskResponse[] = await res.json();
+        const loaded = data.map((t) => ({ id: t._id, title: t.title }));
+        setTasks(loaded);
+
+        if (pendingTaskIds !== null) {
+          setSelectedTaskIds(pendingTaskIds);
+          setPendingTaskIds(null);
+        }
+      } catch (err) {
+        console.error("Failed to load tasks:", err);
+        setTasksError("Unable to load tasks right now.");
+      } finally {
+        setTasksLoading(false);
+      }
+    };
+
+    fetchTasks();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (pendingTaskIds !== null && !tasksLoading) {
+      setSelectedTaskIds(pendingTaskIds);
+      setPendingTaskIds(null);
+    }
+  }, [tasksLoading, pendingTaskIds]);
+
+  useEffect(() => {
+    if (!challengeId) return;
+
+    const fetchChallenge = async () => {
+      try {
+        const res = await fetch(`/api/challenges/${challengeId}`, { cache: "no-store" });
+        const data = await res.json();
+
+        if (!res.ok) throw new Error(data?.error ?? "Failed to load challenge.");
+
+        const totalMinutes = typeof data.time === "number" ? data.time : 0;
+
+        setTitle(data.title ?? "");
+        setDescription(data.description ?? "");
+        setSelectedTags(Array.isArray(data.tags) ? data.tags : []);
+        setIsActive(Boolean(data.isActive));
+        setHours(String(Math.floor(totalMinutes / 60)));
+        setMinutes(String(totalMinutes % 60));
+        setShowAllTags(true);
+
+        const ids: string[] = Array.isArray(data.task_ids)
+          ? data.task_ids.map((t: TaskResponse | string) => (typeof t === "string" ? t : t._id))
+          : [];
+
+        // If tasks already loaded apply immediately, otherwise queue them
+        if (!tasksLoading) {
+          setSelectedTaskIds(ids);
+        } else {
+          setPendingTaskIds(ids);
+        }
+      } catch (err) {
+        console.error("Failed to load challenge:", err);
+        setError(err instanceof Error ? err.message : "Unable to load challenge.");
+      }
+    };
+
+    fetchChallenge();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [challengeId]);
 
   const toggleTag = (label: string) => {
     setSelectedTags((prev) => (prev.includes(label) ? prev.filter((t) => t !== label) : [...prev, label]));
@@ -59,35 +140,8 @@ function NewChallengeForm() {
     setSelectedTaskIds((prev) => prev.filter((t) => t !== id));
   };
 
-  useEffect(() => {
-    const fetchTasks = async () => {
-      setTasksLoading(true);
-      setTasksError("");
-      try {
-        const res = await fetch("/api/task", { cache: "no-store" });
-        if (!res.ok) throw new Error("Failed to load tasks");
-        const data: TaskResponse[] = await res.json();
-        setTasks(data.map((t) => ({ id: t._id, title: t.title })));
-      } catch (err) {
-        console.error("Failed to load tasks:", err);
-        setTasksError("Unable to load tasks right now.");
-      } finally {
-        setTasksLoading(false);
-      }
-    };
-
-    fetchTasks();
-  }, []);
-
   const filteredTasks = tasks.filter((t) => t.title.toLowerCase().includes(taskSearch.trim().toLowerCase()));
-
   const selectedTasks = tasks.filter((t) => selectedTaskIds.includes(t.id));
-
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const challengeId = searchParams.get("challengeId");
-  const isEditMode = Boolean(challengeId);
 
   const handleSave = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -110,24 +164,15 @@ function NewChallengeForm() {
     try {
       const userResponse = await fetch("/api/user", {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
       });
 
       const allUsers = await userResponse.json().catch(() => null);
-
-      if (!userResponse.ok) {
-        throw new Error(allUsers?.error ?? `Failed to fetch users.`);
-      }
-
-      console.log(allUsers);
+      if (!userResponse.ok) throw new Error(allUsers?.error ?? "Failed to fetch users.");
 
       const response = await fetch(isEditMode && challengeId ? `/api/challenges/${challengeId}` : "/api/challenges", {
         method: isEditMode ? "PATCH" : "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           title: title.trim(),
           description: description.trim(),
@@ -140,10 +185,7 @@ function NewChallengeForm() {
       });
 
       const data = await response.json().catch(() => null);
-
-      if (!response.ok) {
-        throw new Error(data?.error ?? `Failed to ${isEditMode ? "update" : "create"} challenge.`);
-      }
+      if (!response.ok) throw new Error(data?.error ?? `Failed to ${isEditMode ? "update" : "create"} challenge.`);
 
       router.push("/admin/manage-challenges");
       router.refresh();
@@ -168,7 +210,7 @@ function NewChallengeForm() {
                 <LuChevronLeft size={28} />
               </Link>
               <Text fontWeight="semibold" fontSize="4xl">
-                New Challenge
+                {isEditMode ? "Edit Challenge" : "New Challenge"}
               </Text>
             </HStack>
 
@@ -218,6 +260,7 @@ function NewChallengeForm() {
                       return (
                         <Button
                           key={tag.label}
+                          type="button"
                           size="sm"
                           borderRadius="full"
                           variant="outline"
@@ -233,6 +276,7 @@ function NewChallengeForm() {
                     })}
                     {!showAllTags && hiddenCount > 0 && (
                       <Button
+                        type="button"
                         size="sm"
                         borderRadius="full"
                         variant="outline"

--- a/src/app/admin/manage-challenges/page.tsx
+++ b/src/app/admin/manage-challenges/page.tsx
@@ -91,6 +91,12 @@ export default function ManageChallengePage() {
     challenge.title.toLowerCase().includes(searchTerm.trim().toLowerCase()),
   );
 
+  const handleDelete = async (id: string) => {
+    const res = await fetch(`/api/challenges/${id}`, { method: "DELETE" });
+    if (!res.ok) throw new Error("Failed to delete");
+    setChallenges((prev) => prev.filter((c) => c.id !== id));
+  };
+
   const renderChallengeContent = () => {
     if (isLoading) {
       return (
@@ -127,9 +133,11 @@ export default function ManageChallengePage() {
     return filteredChallenges.map((challenge) => (
       <AdminChallengeCard
         key={challenge.id}
+        id={challenge.id}
         title={challenge.title}
         description={challenge.description}
         isActive={challenge.isActive}
+        onDelete={handleDelete}
       />
     ));
   };

--- a/src/components/AdminChallengeCard.tsx
+++ b/src/components/AdminChallengeCard.tsx
@@ -1,13 +1,34 @@
+"use client";
 import { Collapsible, HStack, IconButton, Menu, Portal, Text, VStack } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
 import { LuEllipsisVertical } from "react-icons/lu";
 
 interface AdminChallengeCardProps {
+  id: string;
   title: string;
   description: string;
   isActive: boolean;
+  onDelete: (id: string) => Promise<void>;
 }
 
-export default function AdminChallengeCard({ title, description, isActive }: AdminChallengeCardProps) {
+export default function AdminChallengeCard({ id, title, description, isActive, onDelete }: AdminChallengeCardProps) {
+  const router = useRouter();
+
+  const handleEdit = () => {
+    router.push(`/admin/manage-challenges/new-challenge?challengeId=${id}`);
+  };
+
+  const handleDelete = async () => {
+    const confirmed = window.confirm(`Are you sure you want to delete "${title}"?`);
+    if (!confirmed) return;
+    try {
+      await onDelete(id);
+    } catch (error) {
+      console.error("Failed to delete challenge:", error);
+      alert("Failed to delete challenge. Please try again.");
+    }
+  };
+
   return (
     <Collapsible.Root>
       <VStack
@@ -19,7 +40,6 @@ export default function AdminChallengeCard({ title, description, isActive }: Adm
         align="stretch"
         boxShadow={"0px 1px 8px rgba(89, 91, 98, 0.1)"}
       >
-        {/* Header */}
         <HStack h="100%" w="100%" align="flex-start" gap={2}>
           <Collapsible.Trigger transition="transform 0.2s" flex="1" minW={0} w="100%" textAlign="left">
             <VStack align="flex-start" gap={0} minW={0} w="100%">
@@ -49,6 +69,7 @@ export default function AdminChallengeCard({ title, description, isActive }: Adm
               </Text>
             </VStack>
           </Collapsible.Trigger>
+
           <Menu.Root>
             <Menu.Trigger asChild>
               <IconButton
@@ -66,14 +87,18 @@ export default function AdminChallengeCard({ title, description, isActive }: Adm
             <Portal>
               <Menu.Positioner>
                 <Menu.Content>
-                  <Menu.Item value="edit-challenge">Edit</Menu.Item>
-                  <Menu.Item value="delete-challenge">Delete</Menu.Item>
+                  <Menu.Item value="edit-challenge" onClick={handleEdit}>
+                    Edit
+                  </Menu.Item>
+                  <Menu.Item value="delete-challenge" onClick={handleDelete}>
+                    Delete
+                  </Menu.Item>
                 </Menu.Content>
               </Menu.Positioner>
             </Portal>
           </Menu.Root>
         </HStack>
-        {/* Full Description */}
+
         <Collapsible.Content>
           <Text color="gray.600" fontSize="sm" pt={3}>
             {description}


### PR DESCRIPTION
## Developer: Victor Herrera

Closes #130 

### Pull Request Summary

Admins can now edit and delete challenges from the challenge list.

### Modifications

AdminChallengeCard.tsx - added edit and delete actions to 3-dot menu
manage-challenges/page.tsx - added delete handler
new-challenge/page.tsx - pre fills form when editing, fixed task selection timing

### Testing Considerations

Edit opens form with existing data pre-filled
Delete confirms then removes challenge and its task assignments
Task deletion is already done in /api/challenges/${challengeId}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

https://drive.google.com/file/d/1no6szmdSE96i-XIbdE1Aihco1OdYoBYz/view?usp=sharing
